### PR TITLE
Fix: diango.template

### DIFF
--- a/paste/views.py
+++ b/paste/views.py
@@ -2,7 +2,7 @@ from django.shortcuts import render
 
 from .forms import ArticuloForm
 from django.http import HttpResponseRedirect
-from django.core.context_processors import csrf
+from django.template.context_processors import csrf
 
 # Create your views here.
 


### PR DESCRIPTION
Fix: Según la documentación (https://docs.djangoproject.com/es/1.9/ref/templates/api/), el módulo es desde la 1.8 'django.template.context_processors'
